### PR TITLE
Conform json fields to what the logstash pipeline expects

### DIFF
--- a/FORK.md
+++ b/FORK.md
@@ -29,8 +29,8 @@ Passing extra fields to log messages (will be part of @fields)
 		
 Sample
 
-		{"@source":"MacErnest"
-		,"@type":"glog","@timestamp":"2014-03-21T10:52:05.495118455+01:00"
+		{"@source_host":"MacErnest"
+		,"@timestamp":"2014-03-21T10:52:05.495118455+01:00"
 		,"@fields":{"level":"INFO","threadid":02628,"file":"glog_logstash_test.go","line":60,"instance":"ps34"
 		,"role":"webservice"
 		}

--- a/glog_json.go
+++ b/glog_json.go
@@ -24,8 +24,7 @@ import (
 
 /*
 {
-   "@source":"test.here.com",
-   "@type":"glog",
+   "@source_host":"test.here.com",
    "@timestamp":"2013-10-24T09:30:46.947024155+02:00",
    "@fields":{
       "level":"INFO",
@@ -60,9 +59,8 @@ func (d glogJSON) WriteWithStack(data []byte, stack []byte) {
 
 // openEvent writes the "header" part of the JSON message.
 func (d glogJSON) openEvent() {
-	io.WriteString(d.writer, `{"@source":`)
+	io.WriteString(d.writer, `{"@source_host":`)
 	d.encoder.Encode(host) // uses glog package var
-	io.WriteString(d.writer, `,"@type":"glog"`)
 	io.WriteString(d.writer, `,"@timestamp":`)
 	// ignore time information given, take new snapshot
 	d.encoder.Encode(timeNow()) // use testable function stored in var

--- a/glog_logstash_test.go
+++ b/glog_logstash_test.go
@@ -44,8 +44,8 @@ func TestInfoLogstash(t *testing.T) {
 	Flush()
 }
 
-var jsonBegin = `{"@source":"unknownhost"
-,"@type":"glog","@timestamp":"2006-01-02T15:04:05.678901+01:00"
+var jsonBegin = `{"@source_host":"unknownhost"
+,"@timestamp":"2006-01-02T15:04:05.678901+01:00"
 ,"@fields":{"level":"INFO","threadid":`
 
 var jsonEnd = `"file":"glog_logstash_test.go","line":18}


### PR DESCRIPTION
source is renamed to source_host
type is removed because the logstash pipeline adds it.

Change-Id: I253b158b93e5ed2de17f9ce09c19cdecc5e1a9c6
